### PR TITLE
Update redis.ts added return after set call

### DIFF
--- a/lib/drivers/redis.ts
+++ b/lib/drivers/redis.ts
@@ -26,6 +26,7 @@ export class RedisDriver implements CacheDriver {
     const redisKey = `${this.options.prefix}:::${key}`;
     if (ttlInSec) {
       await this.client.set(redisKey, JSON.stringify(value), "EX", ttlInSec);
+      return;
     }
 
     await this.client.set(redisKey, JSON.stringify(value));


### PR DESCRIPTION
Added a return statement after client.set to avoid multiple calls to redis when making call with ttl

Keys are getting stored twice, first with ttl and then without ttl. As a result, ttl feature is not working